### PR TITLE
update sshj version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 group = 'com.github.hiroyuki-sato'
-version = '0.1.4'
+version = '0.1.5'
 
 def digdagVersion = '0.9.13'
 
@@ -26,7 +26,7 @@ dependencies {
     provided 'io.digdag:digdag-spi:' + digdagVersion
     // provided 'io.digdag:digdag-standards:' + digdagVersion
     provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' once digdag 0.8.2 is released to a built-in repository
-    compile 'com.hierynomus:sshj:0.21.1'
+    compile 'com.hierynomus:sshj:0.26.0'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 group = 'com.github.hiroyuki-sato'
-version = '0.1.5'
+version = '0.1.4'
 
 def digdagVersion = '0.9.13'
 


### PR DESCRIPTION
- sshj 0.21.1 has the following problem.
https://github.com/hierynomus/sshj/issues/358

- current sshi version is already fixed.

- sshj 0.21.1だと、1分以内のsshの接続を10分続けると、その後すべてエラーになってしまいます
  - sshj を最新バージョンにしたところ、この現象は起こらなくなりました