### PR TITLE
update sshj version for hung connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     provided 'io.digdag:digdag-spi:' + digdagVersion
     // provided 'io.digdag:digdag-standards:' + digdagVersion
     provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' once digdag 0.8.2 is released to a built-in repository
-    compile 'com.hierynomus:sshj:0.26.0'
+    compile 'com.hierynomus:sshj:0.27.0'
 }
 
 sourceSets {


### PR DESCRIPTION
- sshj 0.26.0 has the following problem.
https://github.com/hierynomus/sshj/issues/466

- Current sshj version fixed.