### PR TITLE
change SSHClient creating

### DIFF
--- a/src/main/java/com/github/hiroyuki_sato/digdag/plugin/SshOperatorFactory.java
+++ b/src/main/java/com/github/hiroyuki_sato/digdag/plugin/SshOperatorFactory.java
@@ -97,9 +97,8 @@ public class SshOperatorFactory
 
                     try {
                         ssh = retryExecutor.run(() -> {
-                            SSHClient sshTmp = null;
                             try {
-                                sshTmp = new SSHClient();
+                                SSHClient sshTmp = new SSHClient();
                                 setupHostKeyVerifier(sshTmp);
                                 sshTmp.connect(host, port);
                                 return sshTmp;


### PR DESCRIPTION
In my environment, still following error.

```
net.schmizz.sshj.transport.TransportException: Received SSH_MSG_UNIMPLEMENTED while exchanging keys (runtime)
```

It seems that retry does not go well.
How about changing it like this?