### PR TITLE
Changed ssh library from sshj to JSch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     provided 'io.digdag:digdag-spi:' + digdagVersion
     // provided 'io.digdag:digdag-standards:' + digdagVersion
     provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' once digdag 0.8.2 is released to a built-in repository
-    compile 'com.hierynomus:sshj:0.27.0'
+    compile 'com.jcraft:jsch:0.1.55'
 }
 
 sourceSets {


### PR DESCRIPTION
JceSecurity which is used for sshj has memory leak.
I'd like to change ssh library from sshj to JSch.

Unfortunately, JSch is not so sophisticated, but I couldn't find other safe ssh library.
Then, there're too many changes.

I checked digdag-plugin-ssh using JSch  ssh connection every 3 seconds on digdag, 
it's no problem so far.

